### PR TITLE
Don't use WXUSINGDLL, use custom flag instead

### DIFF
--- a/src/wxSimpleJSON.h
+++ b/src/wxSimpleJSON.h
@@ -12,18 +12,18 @@
 #include <vector>
 #endif
 
-#ifdef API_CREATING_DLL
-#    define API_EXPORT WXEXPORT
-#elif defined(WXUSINGDLL)
-#    define API_EXPORT WXIMPORT
+#ifdef JSON_CREATING_DLL
+#    define JSON_API_EXPORT WXEXPORT
+#elif defined(JSON_USING_DLL)
+#    define JSON_API_EXPORT WXIMPORT
 #else /* not making nor using DLL */
-#    define API_EXPORT
+#    define JSON_API_EXPORT
 #endif
 
 typedef struct cJSON cJSON;
 
 /// @brief Class for reading, parsing, and writing JSON data.
-class API_EXPORT wxSimpleJSON
+class JSON_API_EXPORT wxSimpleJSON
 {
   protected:
     cJSON *m_d{ nullptr};


### PR DESCRIPTION
WXUSINGDLL may enabled by build systems for something else and may not be what we are wanting when building this library. Instead, use more library-specific JSON_USING_DLL and JSON_CREATING_DLL flags to control DLL import/export options.
Also, don't use API_EXPORT (might conflict with something else), use more specific JSON_API_EXPORT.