### PR TITLE
Remove wxUSE_STL conditions

### DIFF
--- a/src/wxSimpleJSON.cpp
+++ b/src/wxSimpleJSON.cpp
@@ -149,7 +149,6 @@ wxArrayString wxSimpleJSON::GetValueArrayString(const wxMBConv &conv) const
     return arr;
 }
 
-#ifdef wxUSE_STL 
 std::vector<wxString> wxSimpleJSON::GetValueStringVector(const wxMBConv& conv) const
 {
     if (!m_d || (m_d->type != cJSON_Array)) {
@@ -177,7 +176,6 @@ std::vector<wxSimpleJSON::Ptr_t> wxSimpleJSON::GetValueArrayObject() const
     }
     return arr;
 }
-#endif
 
 double wxSimpleJSON::GetValueNumber(double defaultValue) const
 {
@@ -187,7 +185,6 @@ double wxSimpleJSON::GetValueNumber(double defaultValue) const
     return m_d->valuedouble;
 }
 
-#ifdef wxUSE_STL 
 std::vector<double> wxSimpleJSON::GetValueArrayNumber(double defaultValue) const
 {
     if (!m_d || (m_d->type != cJSON_Array)) {
@@ -201,7 +198,6 @@ std::vector<double> wxSimpleJSON::GetValueArrayNumber(double defaultValue) const
     }
     return arr;
 }
-#endif
 
 wxSimpleJSON::Ptr_t wxSimpleJSON::GetProperty(const wxString &name) const
 {
@@ -246,7 +242,6 @@ bool wxSimpleJSON::GetValueBool(bool defaultValue) const
     return m_d->type == cJSON_True;
 }
 
-#ifdef wxUSE_STL 
 std::vector<bool> wxSimpleJSON::GetValueArrayBool(bool defaultValue) const
 {
     if (!m_d || (m_d->type != cJSON_Array)) {
@@ -260,7 +255,6 @@ std::vector<bool> wxSimpleJSON::GetValueArrayBool(bool defaultValue) const
     }
     return arr;
 }
-#endif
 
 wxSimpleJSON::Ptr_t wxSimpleJSON::Create(const wxString &buffer, bool isRoot, const wxMBConv &conv)
 {

--- a/src/wxSimpleJSON.h
+++ b/src/wxSimpleJSON.h
@@ -8,9 +8,7 @@
 #include <wx/dlimpexp.h>
 #include <wx/ffile.h>
 #include <wx/numformatter.h>
-#ifdef wxUSE_STL 
 #include <vector>
-#endif
 
 #ifdef JSON_CREATING_DLL
 #    define JSON_API_EXPORT WXEXPORT
@@ -234,7 +232,7 @@ class JSON_API_EXPORT wxSimpleJSON
      *      you are calling the correct @c GetValue___() function.
      */
     bool GetValueBool(bool defaultValue = false) const;
-#ifdef wxUSE_STL 
+
     /**
      * @brief Returns the node's values as an array of booleans
             (if its type is JSONType::IS_TRUE/IS_FALSE and the array's values are boolean).
@@ -244,7 +242,7 @@ class JSON_API_EXPORT wxSimpleJSON
      *      you are calling the correct @c GetValue___() function.
      */
     std::vector<bool> GetValueArrayBool(bool defaultValue = false) const;
-#endif
+
     /**
      * @brief Returns the node's values as an array of strings
             (if its type is JSONType::IS_ARRAY).
@@ -254,7 +252,7 @@ class JSON_API_EXPORT wxSimpleJSON
      *      you are calling the correct @c GetValue___() function.
      */
     wxArrayString GetValueArrayString(const wxMBConv &conv = wxConvUTF8) const;
-#ifdef wxUSE_STL 
+
     /**
      * @brief Returns the node's values as a vector of strings
             (if its type is JSONType::IS_ARRAY).
@@ -273,7 +271,7 @@ class JSON_API_EXPORT wxSimpleJSON
      *      you are calling the correct @c GetValue___() function.
      */
     std::vector<wxSimpleJSON::Ptr_t> GetValueArrayObject() const;
-#endif
+
     /**
      * @brief Returns the node's value as a double
      *      (if its type is JSONType::IS_NUMBER).
@@ -282,7 +280,7 @@ class JSON_API_EXPORT wxSimpleJSON
      *      you are calling the correct @c GetValue___() function.
      */
     double GetValueNumber(double defaultValue = -1) const;
-#ifdef wxUSE_STL 
+
     /**
      * @brief Returns the node's values as an array of numbers
             (if its type is JSONType::IS_ARRAY and the array's values are numeric).
@@ -292,7 +290,6 @@ class JSON_API_EXPORT wxSimpleJSON
      *      you are calling the correct @c GetValue___() function.
      */
     std::vector<double> GetValueArrayNumber(double defaultValue = -1) const;
-#endif
 
     /**
      * @brief Returns a node's property (by name).


### PR DESCRIPTION
Seems like using wxUSE_STL was not the correct approach in my last PR (that's set to zero under Unix by default).  This PR just removes that.

Looking at the latest wxWidgets 3.3, they appear to be deprecating a lot of the legacy containers like wxArrayString in favor of std::vector.  So always enabling the std::vector stuff in this library seems OK now (IMO).